### PR TITLE
Added text/yml as a deprecate of application/xml

### DIFF
--- a/mimeData.json
+++ b/mimeData.json
@@ -13053,7 +13053,9 @@
     "name": "application/xml",
     "description": "",
     "links": {
-      "deprecates": [],
+      "deprecates": [
+        "text/xml"
+      ],
       "relatedTo": [],
       "parentOf": [],
       "alternativeTo": []

--- a/src/mime_enum/mimetype.py
+++ b/src/mime_enum/mimetype.py
@@ -895,6 +895,7 @@ _ALIASES: dict[str, MimeType] = {
     "text/x-python-script": MimeType("text/x-python"),
     "text/x-yaml": MimeType("application/yaml"),
     "text/x.gcode": MimeType("gcode"),
+    "text/xml": MimeType("application/xml"),
     "text/yaml": MimeType("application/yaml"),
 }
 


### PR DESCRIPTION
While text/xml and application/xml both use .xml and are different text/xml and both still relevant, text/xml could not be added as a standalone since .xml was already taken by application/xml.
Since application/xml is the more preferred type text/yml was added as a deprecate of application/xml for now.

Perhaps changes are necessary in the future.

### Changes

**Before:**
```text
try_parse(text/xml) -> None
```

**After:**
```text
try_parse(text/xml) -> application/xml
```